### PR TITLE
fix(anikoto,hianime): use MegaPlay getSourcesNew for plain m3u8

### DIFF
--- a/index.json
+++ b/index.json
@@ -14,7 +14,7 @@
     {
       "id": "anikoto",
       "name": "AniKoto",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "type": "anime",
       "lang": "en",
       "file": "providers/anikoto.js",
@@ -50,7 +50,7 @@
     {
       "id": "hianime",
       "name": "HiAnime",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "type": "anime",
       "lang": "en",
       "file": "providers/hianime.js",

--- a/providers/anikoto.js
+++ b/providers/anikoto.js
@@ -9,7 +9,9 @@
 //   /ajax/episode/list/<id>     -> [{ data-id, num, sub, dub, data-ids(server_ids) }]
 //   /ajax/server/list?servers=<server_ids> -> server list (VidPlay/HD/Vidstream/…)
 //   /ajax/server?get=<link_id>  -> { url: <player embed>, skip_data }
-//   <embed host>/stream/getSources?id=<embed data-id> -> m3u8 + subs
+//   <embed host>/stream/getSources(New)?id=<embed data-id> -> m3u8 + subs
+//   (MegaPlay/VidWish: getSources returns AES `enc`; getSourcesNew is plain.
+//    VidPlay/vidtube still uses getSources only.)
 //
 // Some episodes only list servers that no longer hand back a plain file. For
 // those the site's own player asks a mapper API for EXTRA servers, keyed by the
@@ -27,15 +29,22 @@ var SITE = 'https://anikototv.to';
 var API = 'https://anikotoapi.site';
 var UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
   + '(KHTML, like Gecko) Chrome/124.0 Safari/537.36';
-// Hosts whose /stream/getSources returns a plain m3u8. VidPlay (vidtube) is the
-// one still doing so; MegaPlay/VidWish are kept as fallbacks.
+// Embed hosts that hand back a plain m3u8 (via getSources or getSourcesNew).
 var PLAYER_RE = /^https?:\/\/(?:[a-z0-9-]+\.)?(?:vidtube\.[a-z]+|megaplay\.[a-z]+|vidwish\.[a-z]+)/i;
 // Extra servers the episode's own list doesn't offer, keyed <mal>/<ep>/<ts>.
 var MAPPER = 'https://mapper.nekostream.site/api/mal/';
 
 function getInfo() {
   return { name: 'AniKoto', lang: 'en', baseUrl: SITE,
-    logo: SITE + '/favicon.ico', type: 'anime', version: '1.0.5' };
+    logo: SITE + '/favicon.ico', type: 'anime', version: '1.0.6' };
+}
+
+// MegaPlay/VidWish encrypt /stream/getSources; /stream/getSourcesNew still
+// returns sources.file. VidPlay (vidtube) only exposes getSources.
+function _sourcesUrl(base, dataId, type) {
+  var path = /(?:megaplay|vidwish)\.[a-z]+/i.test(String(base || ''))
+    ? '/stream/getSourcesNew' : '/stream/getSources';
+  return base + path + '?id=' + dataId + '&type=' + type;
 }
 
 function _mode(opts) { return (opts && opts.category === 'dub') ? 'dub' : 'sub'; }
@@ -260,7 +269,7 @@ function getDetail(url, opts) {
 
 function getEpisodes(url, opts) { return getDetail(url, opts).then(function (d) { return d.episodes; }); }
 
-// ── Streams: server_ids → server list → server?get → MegaPlay getSources ─────
+// ── Streams: server_ids → server list → server?get → embed getSources(New) ───
 function _parseServers(html) {
   var servers = [], re = /data-type="(\w+)"([\s\S]*?)(?=data-type="|$)/g, tm;
   while ((tm = re.exec(html)) !== null) {
@@ -271,9 +280,7 @@ function _parseServers(html) {
   }
   return servers;
 }
-// VidPlay (→ vidtube) still hands back a plain m3u8. Vidstream/HD go to
-// megaplay.buzz, whose getSources now returns an encrypted blob instead of a
-// file, so they're only worth trying if VidPlay is missing for an episode.
+// Prefer VidPlay; Vidstream/HD (MegaPlay) work again via getSourcesNew.
 function _srvRank(name) {
   var n = String(name || '').toLowerCase();
   if (n.indexOf('vidplay') > -1) return 0;
@@ -354,7 +361,7 @@ function _tryServers(list, i, cat) {
   }).catch(function () { return _tryServers(list, i + 1, cat); });
 }
 
-// Embed page → data-id → getSources (plain m3u8 + subtitle tracks).
+// Embed page → data-id → getSources(New) (plain m3u8 + subtitle tracks).
 // When the VTT pack encode id differs from the video pack (common on dub),
 // MegaPlay's intro/outro markers on the sibling pack give the post-OP skew so
 // softsubs line up without a user delay preference.
@@ -400,14 +407,14 @@ function _packSkew(playing, sibling) {
 
 function _extractPlayer(embed, cat) {
   var base = (embed.match(/^(https?:\/\/[^/]+)/) || [])[1] || 'https://vidtube.site';
-  // getSources is keyed by the embed's data-id, which is shared across the
+  // Sources are keyed by the embed's data-id, which is shared across the
   // sub/hsub/dub cuts — the audio comes from `type`, so carry over the one this
   // embed was issued for or a dub episode comes back with the sub stream.
   var type = _cutOf(embed) || cat;
   return _get(embed, SITE + '/').then(function (mhtml) {
     var dataId = (mhtml.match(/data-id="(\d+)"/) || [])[1];
     if (!dataId) throw new Error('AniKoto: no embed id');
-    return fetch(base + '/stream/getSources?id=' + dataId + '&type=' + type, {
+    return fetch(_sourcesUrl(base, dataId, type), {
       headers: { 'User-Agent': UA, 'Referer': embed, 'X-Requested-With': 'XMLHttpRequest' }
     }).then(function (r) {
       var j; try { j = JSON.parse(r.body || 'null'); } catch (e) { throw new Error('AniKoto: bad getSources'); }
@@ -464,8 +471,8 @@ function _extractPlayer(embed, cat) {
         if (!sid) return null;
         // Same id as the playing cut on hosts that share it, so the cut has to
         // be carried too or this reads back the pack we already have.
-        return fetch(base + '/stream/getSources?id=' + sid
-          + '&type=' + (_cutOf(sibEmbed) || (type === 'dub' ? 'sub' : 'dub')), {
+        return fetch(_sourcesUrl(base, sid,
+            _cutOf(sibEmbed) || (type === 'dub' ? 'sub' : 'dub')), {
           headers: { 'User-Agent': UA, 'Referer': sibEmbed, 'X-Requested-With': 'XMLHttpRequest' }
         }).then(function (sr) {
           var sj; try { sj = JSON.parse(sr.body || 'null'); } catch (e) { sj = null; }

--- a/providers/hianime.js
+++ b/providers/hianime.js
@@ -8,16 +8,13 @@
 //   /<slug>                                    -> poster, synopsis, sub/dub ticks
 //   /api/theme/episode/list/<animeId>          -> { html } of ep-item anchors
 //   /api/theme/episode/servers?episodeId=<id>  -> { html }, data-hash = b64 embed
-//   <embed>/stream/getSources?id=&type=        -> m3u8 + subtitle tracks
+//   <embed>/stream/getSources(New)?id=&type=   -> m3u8 + subtitle tracks
 //
 // The anime id is just the trailing number of the slug (dan-da-dan-86 -> 86).
 //
-// Of the servers the site offers, only VidPlay (vidtube) still answers with a
-// plain file: megaplay's getSources returns an encrypted blob instead of
-// `sources`, and Zoko hides its payload behind its own player. Both are left in
-// the fallback order in case megaplay ever reverts, but a title carrying
-// neither VidPlay cut (One Piece, Naruto) fails with "no playable server"
-// rather than pretending to have a stream.
+// VidPlay (vidtube) uses getSources. MegaPlay's getSources returns an encrypted
+// `enc` blob — getSourcesNew restores the plain `sources.file`. Zoko still hides
+// its payload behind its own player and stays out of PLAYER_RE.
 
 var SOURCE_ID = (typeof __SOURCE_ID !== 'undefined' && __SOURCE_ID)
   ? String(__SOURCE_ID) : 'hianime';
@@ -26,13 +23,20 @@ var SITE = 'https://hianime.at';
 var API = SITE + '/api/theme/';
 var UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
   + '(KHTML, like Gecko) Chrome/124.0 Safari/537.36';
-// Embed hosts whose /stream/getSources hands back a plain m3u8. vidtube is the
-// only one still doing it; megaplay stays for the day it starts again.
+// Embed hosts that hand back a plain m3u8 (via getSources or getSourcesNew).
 var PLAYER_RE = /^https?:\/\/(?:[a-z0-9-]+\.)?(?:vidtube\.[a-z]+|megaplay\.[a-z]+)/i;
 
 function getInfo() {
   return { name: 'HiAnime', lang: 'en', baseUrl: SITE,
-    logo: SITE + '/favicon.ico', type: 'anime', version: '1.1.0' };
+    logo: SITE + '/favicon.ico', type: 'anime', version: '1.1.1' };
+}
+
+// MegaPlay encrypts /stream/getSources; /stream/getSourcesNew still returns
+// sources.file. VidPlay (vidtube) only exposes getSources.
+function _sourcesUrl(base, dataId, type) {
+  var path = /megaplay\.[a-z]+/i.test(String(base || ''))
+    ? '/stream/getSourcesNew' : '/stream/getSources';
+  return base + path + '?id=' + dataId + '&type=' + type;
 }
 
 function _mode(opts) { return (opts && opts.category === 'dub') ? 'dub' : 'sub'; }
@@ -331,7 +335,7 @@ function _tryServers(list, i, cat) {
   });
 }
 
-// The cut (sub/hsub/dub) the embed url was issued for. getSources is keyed by
+// The cut (sub/hsub/dub) the embed url was issued for. Sources are keyed by
 // the embed's data-id, and that id is SHARED across the three cuts — the audio
 // comes from `type` alone — so a dub embed asked without it answers with the
 // sub stream.
@@ -345,13 +349,12 @@ function _extractPlayer(embed, cat) {
   return _get(embed, SITE + '/').then(function (mhtml) {
     var dataId = (mhtml.match(/data-id="(\d+)"/) || [])[1];
     if (!dataId) throw new Error('HiAnime: no embed id');
-    return fetch(base + '/stream/getSources?id=' + dataId + '&type=' + type, {
+    return fetch(_sourcesUrl(base, dataId, type), {
       headers: { 'User-Agent': UA, 'Referer': embed, 'X-Requested-With': 'XMLHttpRequest' }
     }).then(function (r) {
       var j; try { j = JSON.parse(r.body || 'null'); } catch (e) { throw new Error('HiAnime: bad getSources'); }
       var s = j && j.sources;
-      // megaplay answers with an encrypted blob and no `sources` — that throw is
-      // what walks us on to the next server.
+      // No sources.file → walk on to the next server.
       var file = s ? (s.file || (s[0] && s[0].file)) : null;
       if (!file) throw new Error('HiAnime: no stream file');
       var subs = [], tracks = (j && j.tracks) || [];


### PR DESCRIPTION
## Summary
- MegaPlay’s `/stream/getSources` now returns an AES-encrypted `enc` blob instead of `sources.file`, which made AniKoto/HiAnime fail with “no playable server” when only MegaPlay-backed servers were available.
- Route MegaPlay/VidWish embeds through `/stream/getSourcesNew` (still returns plain `sources.file`); keep VidPlay (vidtube) on `/stream/getSources`.
- Bump AniKoto to `1.0.6` and HiAnime to `1.1.1`.

## Test plan
- [ ] Refresh AniKoto/HiAnime from this repo and confirm versions update
- [ ] Play an episode that only lists Vidstream/HD (MegaPlay) — e.g. Re:Zero — and confirm stream resolves
- [ ] Confirm logs hit `getSourcesNew` and return an m3u8 `sources.file`
- [ ] Spot-check a title that still has VidPlay and confirm it still plays